### PR TITLE
Fix for #81

### DIFF
--- a/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
+++ b/src/Umbraco.Community.Contentment/DataEditors/DropdownList/dropdown-list.js
@@ -29,7 +29,12 @@ angular.module("umbraco").controller("Umbraco.Community.Contentment.DataEditors.
             vm.items = config.items.slice();
 
             vm.allowEmpty = Object.toBoolean(config.allowEmpty) && vm.items.some(x => x.value === $scope.model.value);
-
+            
+            if(vm.allowEmpty === false && $scope.model.value === '' && vm.items.length > 0) {
+                // set to first item in list when no empty values are allowed.
+                $scope.model.value = vm.items[0].value;
+            }
+            
             vm.htmlAttributes = config.htmlAttributes;
 
             vm.uniqueId = $scope.model.hasOwnProperty("dataTypeKey")


### PR DESCRIPTION
### Description
This sets the selected value to the first item in the list when creating new content and no empty items are allowed.

### Related Issues?

Fixes #81

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
     Please do not upgrade any NuGet dependencies.
     Please do not modify any licensing information, e.g. do not update the copyright year. -->

- [ ] Documentation change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the coding style of this project.
- [x] My changes generate no new warnings.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the corresponding documentation.
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING)** and **[CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)** documents.
